### PR TITLE
fix:  cannot click compact menu when tweet is long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.11.2
+
+## Bug Fixes
+
+* Fix cannot click compact menu when tweet is long(#273)
+
 # v1.11.1
 
 ## Bug Fixes

--- a/apps/block/google_search_inner_card.ts
+++ b/apps/block/google_search_inner_card.ts
@@ -43,6 +43,7 @@ class GoogleSearchInnerCard extends SearchResultToBlock {
             this.title = heading.textContent ? heading.textContent : '';
         }
 
+        element.setAttribute('data-gsb-element-type', 'google-search-inner-card');
         this.valid = true;
         [this.url] = urlList;
     }

--- a/apps/content_script/block_mediator.ts
+++ b/apps/content_script/block_mediator.ts
@@ -319,6 +319,7 @@ class BlockMediator implements IBasicBlockMediator, IBlockMediator {
         menuPosition: MenuPosition,
     ) {
         const blockTarget = new BlockTargetElement(this, g.getElement());
+        g.getElement().setAttribute('data-gsb-menu-position', menuPosition.toString());
 
         this.operationDiv = $.div('block-anchor');
         this.url = g.getUrl();

--- a/apps/styles/google.css
+++ b/apps/styles/google.css
@@ -155,8 +155,9 @@ g-inner-card:not([data-blocker-display=none]) > span.block-anchor {
     top: 16px;
 }
 
-.cv2VAd {
-    height: auto !important;
+[data-gsb-element-type='google-search-inner-card'][data-gsb-menu-position='compact'] {
+    height: 360px !important;
+    max-height: 360px !important;
 }
 
 /* for compact menu in 'News' tab */


### PR DESCRIPTION
closes #273