### PR TITLE
fix: Correct button references to input

### DIFF
--- a/apps/entry/options.ts
+++ b/apps/entry/options.ts
@@ -27,14 +27,14 @@ const softBlockList = assertDivElement(
 const hardBlockList = assertDivElement(
   document.getElementById("hardBlockList"),
 );
-const clearButton = assertButtonElement(document.getElementById("clearButton"));
+const clearButton = assertInputElement(document.getElementById("clearButton"));
 
-function assertButtonElement(element: HTMLElement | null): HTMLButtonElement {
+function assertInputElement(element: HTMLElement | null): HTMLInputElement {
   if (!element) {
-    throw new Error("bannedWordAddButton is null");
+    throw new Error("Input is null");
   }
-  if (!(element instanceof HTMLButtonElement)) {
-    throw new Error("bannedWordAddButton is not HTMLButtonElement");
+  if (!(element instanceof HTMLInputElement)) {
+    throw new Error("Input is not HTMLInputElement");
   }
   return element;
 }

--- a/apps/page/option/banned_word.ts
+++ b/apps/page/option/banned_word.ts
@@ -35,7 +35,7 @@ export default class BannedWords {
   private wordList;
 
   constructor() {
-    this.addButton = this.assertButtonElement(
+    this.addButton = this.assertInputElement(
       document.getElementById("bannedWordAddButton"),
     );
     this.addText = this.assertInputElement(
@@ -64,16 +64,6 @@ export default class BannedWords {
 
       this.addText.value = "";
     });
-  }
-
-  private assertButtonElement(element: HTMLElement | null): HTMLButtonElement {
-    if (!element) {
-      throw new Error("bannedWordAddButton is null");
-    }
-    if (!(element instanceof HTMLButtonElement)) {
-      throw new Error("bannedWordAddButton is not HTMLButtonElement");
-    }
-    return element;
   }
 
   private assertDivElement(element: HTMLElement | null): HTMLDivElement {

--- a/apps/page/option/regexp.ts
+++ b/apps/page/option/regexp.ts
@@ -17,7 +17,7 @@ class RegExpList {
     this.addText = this.assertInputElement(
       document.getElementById("regexpAddText"),
     );
-    this.addButton = this.assertButtonElement(
+    this.addButton = this.assertInputElement(
       document.getElementById("regexpAddButton"),
     );
     $.onclick(this.addButton, this.addItem.bind(this));
@@ -117,16 +117,6 @@ class RegExpList {
     $.removeSelf(div);
   }
 
-  private assertButtonElement(element: HTMLElement | null): HTMLButtonElement {
-    if (!element) {
-      throw new Error("bannedWordAddButton is null");
-    }
-    if (!(element instanceof HTMLButtonElement)) {
-      throw new Error("bannedWordAddButton is not HTMLButtonElement");
-    }
-    return element;
-  }
-
   private assertDivElement(element: HTMLElement | null): HTMLDivElement {
     if (!element) {
       throw new Error("bannedWord text is null");
@@ -139,10 +129,10 @@ class RegExpList {
 
   private assertInputElement(element: HTMLElement | null): HTMLInputElement {
     if (!element) {
-      throw new Error("bannedWord Input is null");
+      throw new Error("Input is null");
     }
     if (!(element instanceof HTMLInputElement)) {
-      throw new Error("bannedWord Input is not HTMLInputElement");
+      throw new Error("Input is not HTMLInputElement");
     }
     return element;
   }


### PR DESCRIPTION
Changed instances that incorrectly referred to certain elements as buttons
when they should have been inputs. Updated relevant error messages and
removed redundant button assertion functions.
