### PR TITLE
fix(ci): add missing GITHUB_TOKEN for snapshot release deletion

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,8 @@ jobs:
           gh release delete snapshot -y || true
           git push origin :refs/tags/snapshot || true
           set -e
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create/Push snapshot tag
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
The snapshot release deletion step was failing because GITHUB_TOKEN
environment variable was not set, causing old draft releases to accumulate.
This adds the missing token to allow proper cleanup of existing snapshot
releases before creating new ones.
