### PR TITLE
release: bump version to 1.16.1.1 for beta release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,8 +195,8 @@ For beta releases after manual testing (e.g., 1.16.1 → 1.16.1.1 for Chrome ext
 
 1. **Version Update**:
    - Update `package.json` version by appending `.1` to current release (e.g., 1.16.1.1)
+   - Update `public/manifest.json` and `public/manifest.firefox.json` versions manually
    - This follows Chrome extension versioning convention, not semver
-   - Manifest versions will be automatically synced
 
 2. **Beta Release Creation**:
    - No tag creation required - release from snapshot

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossip-site-blocker",
-  "version": "1.16.1",
+  "version": "1.16.1.1",
   "license": "MIT",
   "author": "Hideki Ikemoto",
   "type": "module",

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "1.16.1",
+  "version": "1.16.1.1",
   "default_locale": "en",
   "description": "__MSG_extensionDescription__",
   "icons": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.16.1",
+  "version": "1.16.1.1",
   "default_locale": "en",
   "description": "__MSG_extensionDescription__",
   "icons": {


### PR DESCRIPTION
## Summary
- Bump version from 1.16.1 to 1.16.1.1 for beta release
- Following Chrome extension versioning convention for beta releases

## Test plan
- [x] Version updated in package.json
- [ ] Manual testing will be performed using snapshot assets after CI build

🤖 Generated with [Claude Code](https://claude.ai/code)