### PR TITLE
fix: add support for MjjYud class in Google search result detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,8 @@ pnpm format  # Prettier + sort-package-json
 pnpm lint    # ESLint + TypeScript + dependency checks
 ```
 
+**IMPORTANT**: Always run `pnpm format`, `pnpm lint`, and `pnpm test` before creating PRs to ensure code quality and functionality.
+
 ### CI/CD
 
 `make ci` executes:

--- a/apps/block/google_search_result.ts
+++ b/apps/block/google_search_result.ts
@@ -22,12 +22,19 @@ export class GoogleSearchResult extends SearchResultToBlock {
   private readonly compactMenuInsertElement: Element;
 
   static isCandidate(element: Element, documentURL: DocumentURL): boolean {
-    if (element.hasAttribute("data-rpos") && documentURL.isGoogleSearch()) {
-      if ($.hasParentWithClass(element, "related-question-pair")) {
-        return false;
+    if (documentURL.isGoogleSearch()) {
+      // Check for data-rpos attribute
+      if (element.hasAttribute("data-rpos")) {
+        if ($.hasParentWithClass(element, "related-question-pair")) {
+          return false;
+        }
+        return true;
       }
 
-      return true;
+      // Check for MjjYud class
+      if (element.classList.contains("MjjYud")) {
+        return true;
+      }
     }
 
     return false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossip-site-blocker",
-  "version": "1.16.1.1",
+  "version": "1.16.1.2",
   "license": "MIT",
   "author": "Hideki Ikemoto",
   "type": "module",

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "1.16.1.1",
+  "version": "1.16.1.2",
   "default_locale": "en",
   "description": "__MSG_extensionDescription__",
   "icons": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.16.1.1",
+  "version": "1.16.1.2",
   "default_locale": "en",
   "description": "__MSG_extensionDescription__",
   "icons": {


### PR DESCRIPTION
## Summary

- Restore MjjYud class detection that was removed in PR #1766
- Keep data-rpos attribute detection for both Google search result formats  
- Update version to 1.16.1.2 for beta release
- Update CLAUDE.md with PR creation guidelines

## Background

PR #1766 replaced MjjYud class detection with data-rpos attribute detection, but this was a regression. Google search results actually use both patterns:
- Some results use MjjYud class 
- Some results use data-rpos attribute

Removing MjjYud detection broke blocking functionality for search results that use the MjjYud class pattern.

## Changes

- Restored MjjYud class detection alongside existing data-rpos attribute detection
- Both detection methods are now supported to handle all Google search result formats
- Updated package.json and manifest files to version 1.16.1.2
- Added PR creation guidelines to CLAUDE.md

## Test plan

- [x] Run `pnpm format`, `pnpm lint`, and `pnpm test` - all passed
- [x] Build extension and test Google search result blocking functionality
- [ ] Test with both MjjYud and data-rpos search result formats
- [ ] Verify blocking functionality works correctly for both patterns

🤖 Generated with [Claude Code](https://claude.ai/code)