### PR TITLE
Release v1.16.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,3 +203,17 @@ For beta releases after manual testing (e.g., 1.16.1 → 1.16.1.1 for Chrome ext
 2. **Beta Release Creation**:
    - No tag creation required - release from snapshot
    - Download updated assets from snapshot after CI build completes
+
+### Production Release Process
+
+For production releases from beta (e.g., 1.16.1.2 → 1.16.2):
+
+1. **Version Update**:
+   - Update `package.json` version to the production version (e.g., 1.16.2)
+   - Update `public/manifest.json` and `public/manifest.firefox.json` versions manually
+   - Run formatting and linting: `pnpm format && pnpm lint`
+
+2. **Release Creation**:
+   - Create PR with version updates and merge to main branch
+   - Create release using GitHub CLI: `gh release create v1.16.2 --generate-notes`
+   - Version follows semantic versioning for minor updates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossip-site-blocker",
-  "version": "1.16.1.2",
+  "version": "1.16.2",
   "license": "MIT",
   "author": "Hideki Ikemoto",
   "type": "module",

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "1.16.1.2",
+  "version": "1.16.2",
   "default_locale": "en",
   "description": "__MSG_extensionDescription__",
   "icons": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.16.1.2",
+  "version": "1.16.2",
   "default_locale": "en",
   "description": "__MSG_extensionDescription__",
   "icons": {


### PR DESCRIPTION
## Summary
- Bump version from 1.16.1.2 to 1.16.2 for production release
- Update all manifest files with new version
- Add production release process documentation to CLAUDE.md

## Changes
- Updated `package.json` version to 1.16.2
- Updated `public/manifest.json` version to 1.16.2  
- Updated `public/manifest.firefox.json` version to 1.16.2
- Added production release process section to CLAUDE.md

🤖 Generated with [Claude Code](https://claude.ai/code)