### PR TITLE
fix: prevent duplicate "Block this page" buttons in search results

### DIFF
--- a/apps/block/google_search_result.ts
+++ b/apps/block/google_search_result.ts
@@ -23,6 +23,11 @@ export class GoogleSearchResult extends SearchResultToBlock {
 
   static isCandidate(element: Element, documentURL: DocumentURL): boolean {
     if (documentURL.isGoogleSearch()) {
+      // Skip if already processed
+      if (element.hasAttribute("data-gsb-element-type")) {
+        return false;
+      }
+
       // Check for data-rpos attribute
       if (element.hasAttribute("data-rpos")) {
         if ($.hasParentWithClass(element, "related-question-pair")) {
@@ -33,6 +38,10 @@ export class GoogleSearchResult extends SearchResultToBlock {
 
       // Check for MjjYud class
       if (element.classList.contains("MjjYud")) {
+        // Skip if this MjjYud contains any child with data-rpos (prefer child processing)
+        if (element.querySelector("[data-rpos]")) {
+          return false;
+        }
         return true;
       }
     }


### PR DESCRIPTION
## Summary
- Fixes duplicate "Block this page" buttons appearing in Google search results
- Resolves issue where both parent and child elements were being processed by MutationObserver
- Implements priority-based element processing to prevent UI duplication

## Changes
- Add duplicate processing check using `data-gsb-element-type` attribute
- Prioritize child element (`data-rpos`) processing over parent (`MjjYud`) elements
- Prevent parent elements from being processed when children already match criteria

## Test plan
- [x] Verify tests pass
- [x] Build extension successfully  
- [x] Manual testing in browser shows single "Block this page" button per result
- [x] Confirm fine-grained blocking functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)