### PR TITLE
fix: ensure background color is applied when temporarily unblocking search results

### DIFF
--- a/public/css/google.css
+++ b/public/css/google.css
@@ -9,7 +9,8 @@
 /**
  * color when unhide
  */
-[data-blocker-display="unhide"] {
+[data-blocker-display="unhide"],
+[data-blocker-display="unhide"] > .Ww4FFb {
   background-color: #ffd2d2 !important;
 }
 


### PR DESCRIPTION
## Summary
- Fixes missing pink background color when temporarily unblocking Google search results
- Resolves CSS specificity issue with nested Google search result elements

## Problem
When users clicked "temporarily unblock" on a blocked search result, the expected pink background color (`#ffd2d2`) was not appearing due to Google's nested DOM structure using `.Ww4FFb` class elements.

## Solution
- Added CSS rule targeting `.Ww4FFb` child elements within temporarily unblocked results
- Maintains consistent visual feedback across all Google search result variations

## Changes
```css
[data-blocker-display="unhide"],
[data-blocker-display="unhide"] > .Ww4FFb {
  background-color: #ffd2d2 \!important;
}
```

## Test plan
- [x] Verify tests pass
- [x] Build extension successfully  
- [x] Manual testing confirms pink background appears when temporarily unblocking results
- [x] No impact on other blocking functionality

🤖 Generated with [Claude Code](https://claude.ai/code)