### PR TITLE
fix: improve compact menu positioning to avoid click interference

### DIFF
--- a/apps/block/google_search_result.ts
+++ b/apps/block/google_search_result.ts
@@ -164,7 +164,20 @@ export class GoogleSearchResult extends SearchResultToBlock {
     if (actionMenu !== null) {
       this.compactMenuInsertElement = actionMenu;
     } else {
-      this.compactMenuInsertElement = element.querySelector("a")!;
+      // Place compact menu outside of <a> tag - after the V9tjod span container
+      const linkSpan = element.querySelector(".V9tjod");
+
+      if (linkSpan) {
+        this.compactMenuInsertElement = linkSpan;
+      } else {
+        // Fallback to .b8lM7 container (wraps the main link)
+        const linkWrapper = element.querySelector(".b8lM7");
+        if (linkWrapper) {
+          this.compactMenuInsertElement = linkWrapper;
+        } else {
+          this.compactMenuInsertElement = element.querySelector("a")!;
+        }
+      }
     }
   }
 

--- a/public/css/google.css
+++ b/public/css/google.css
@@ -201,7 +201,10 @@ g-inner-card:not([data-blocker-display="none"]) > span.block-anchor {
 }
 
 .gsb-compact-menu-block-anchor {
-  margin-left: 5px;
+  position: absolute;
+  left: -20px;
+  top: 10px;
+  z-index: 10;
 }
 
 /* HACK for compact menu */


### PR DESCRIPTION
## Summary
- Fixes compact menu icon positioning that was causing click interference
- Resolves issue where compact menu clicks triggered parent link navigation
- Improves overall user experience for compact menu mode

## Problem
The compact menu icon was being inserted inside `<a>` tags, causing:
- Clicks on the compact menu icon to navigate to the linked page instead of opening the menu
- Poor user experience in compact mode
- Inconsistent behavior between default and compact menu modes

## Solution
- **DOM positioning**: Move compact menu insertion point to `.V9tjod` container (outside of `<a>` tags)
- **CSS positioning**: Use `position: absolute` with `left: -20px, top: 10px` for compact placement
- **Click isolation**: Ensure compact menu clicks don't interfere with existing Google UI elements

## Changes
### `apps/block/google_search_result.ts`
- Enhanced `getCompactMenuInsertElement()` logic to target `.V9tjod` container
- Added fallback hierarchy for robust positioning across different Google layouts

### `public/css/google.css`
- Updated `.gsb-compact-menu-block-anchor` to use absolute positioning
- Optimized spacing and z-index for proper visual layering

## Test plan
- [x] Verify tests pass
- [x] Build extension successfully  
- [x] Manual testing confirms compact menu opens correctly without navigation
- [x] No visual regression in default menu mode
- [x] Proper positioning across different Google search result layouts

🤖 Generated with [Claude Code](https://claude.ai/code)