### PR TITLE
chore: bump version to 1.16.2.1 for beta release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossip-site-blocker",
-  "version": "1.16.2",
+  "version": "1.16.2.1",
   "license": "MIT",
   "author": "Hideki Ikemoto",
   "type": "module",

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "1.16.2",
+  "version": "1.16.2.1",
   "default_locale": "en",
   "description": "__MSG_extensionDescription__",
   "icons": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.16.2",
+  "version": "1.16.2.1",
   "default_locale": "en",
   "description": "__MSG_extensionDescription__",
   "icons": {


### PR DESCRIPTION
## Summary

Bump version to 1.16.2.1 for beta release of dark mode support features.

### Changes Made

- Update `package.json` version from 1.16.2 to 1.16.2.1
- Update `public/manifest.json` version to 1.16.2.1  
- Update `public/manifest.firefox.json` version to 1.16.2.1

### Beta Release Process

Following the beta release process outlined in CLAUDE.md:
- Version updated by appending `.1` to current release (Chrome extension versioning convention)
- No tag creation required - will release from snapshot
- Updated assets will be available from snapshot after CI build completes

### Test Plan

Manual testing has been completed for:
- [x] Google search result blocking functionality
- [x] Google image search blocking functionality  
- [x] Settings page functionality
- [x] Dark mode support for all UI components
- [x] Console error checks

🤖 Generated with [Claude Code](https://claude.ai/code)