### PR TITLE
chore: bump version to 1.17.0 for production release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossip-site-blocker",
-  "version": "1.16.2.1",
+  "version": "1.17.0",
   "license": "MIT",
   "author": "Hideki Ikemoto",
   "type": "module",

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "1.16.2.1",
+  "version": "1.17.0",
   "default_locale": "en",
   "description": "__MSG_extensionDescription__",
   "icons": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.16.2.1",
+  "version": "1.17.0",
   "default_locale": "en",
   "description": "__MSG_extensionDescription__",
   "icons": {


### PR DESCRIPTION
## Summary

Bump version to 1.17.0 for production release including dark mode support and duplicate button fixes.

### Changes Made

- Update `package.json` version from 1.16.2.1 to 1.17.0
- Update `public/manifest.json` version to 1.17.0
- Update `public/manifest.firefox.json` version to 1.17.0

### Production Release Process

Following the production release process outlined in CLAUDE.md:
- Version follows semantic versioning for minor updates (1.16.2 → 1.17.0)
- Includes comprehensive dark mode support features
- Includes fix for duplicate "Block this page" buttons
- Ready for GitHub release creation after merge

### Features Included

#### Dark Mode Support
- Dark mode background colors for temporarily unblocked search results
- Dark mode styling for block dialogs
- Dark mode support for compact menu and appbar icons

#### Bug Fixes
- Fixed duplicate "Block this page" buttons in search results
- Improved element processing logic in MutationObserver

### Test Plan

Manual testing has been completed for both beta and production builds:
- [x] Google search result blocking functionality
- [x] Google image search blocking functionality
- [x] Settings page functionality
- [x] Dark mode support for all UI components
- [x] No duplicate buttons in search results
- [x] Console error checks

🤖 Generated with [Claude Code](https://claude.ai/code)