### PR TITLE
fix: update postcss to address vulnerability

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1106,8 +1106,8 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2376,7 +2376,7 @@ snapshots:
 
   pidtree@0.6.0: {}
 
-  postcss@8.5.6:
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -2596,7 +2596,7 @@ snapshots:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
+      postcss: 8.5.14
       rollup: 4.60.3
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
## Updated packages

- postcss: 8.5.6 → 8.5.14 (patch update)

## Alerts to be resolved (1)

- [alert 50](https://github.com/ikemo3/gossip-site-blocker/security/dependabot/50): postcss medium (fixed in 8.5.10)

## Risk assessment

Patch update within the caret range. No impact on application code.

## Test plan

- [x] pnpm lint
- [x] pnpm test

🤖 Generated with [Claude Code](https://claude.com/claude-code)