### PR TITLE
chore: clean up tsconfig for TypeScript 6 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "alwaysStrict": false,
-    "module": "es2022",
-    "moduleResolution": "node",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "sourceMap": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
## Summary

- Remove deprecated `alwaysStrict: false` (redundant under ESM)
- Change `moduleResolution` from `node` to `bundler` (Vite project)
- Change `module` from `es2022` to `esnext` to pair with bundler resolution

These options trigger deprecation errors under TypeScript 6.0 (`TS5107`). Cleaning up here unblocks #2084 (Renovate's TypeScript 6 update).

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (47/47)
- [x] `tsc --noEmit` passes on TS 5.9
- [ ] Verify CI is green