### PR TITLE
chore: explicitly include chrome types in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "skipLibCheck": true,
     "strict": true,
     "strictPropertyInitialization": false,
-    "target": "es2022"
+    "target": "es2022",
+    "types": ["chrome"]
   },
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary

- TypeScript 6 stops auto-including `@types/chrome` when `types` is unspecified in tsconfig, breaking the global `chrome` namespace used throughout the codebase (24 errors in #2084 CI).
- Pin `types: ["chrome"]` so the build works under both TS5 (current) and TS6 (#2084).

## Test plan

- [x] `pnpm lint` passes locally
- [x] `pnpm test` passes locally (47/47)
- [ ] CI green
- [ ] Confirm #2084 CI also goes green after rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)