### PR TITLE
chore: pnpm v11 migration (workspace config)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 env:
   node-version: "24.16.0"
-  pnpm-version: "10.33.4"
+  pnpm-version: "11.3.0"
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   node-version: "24.16.0"
-  pnpm-version: "10.33.4"
+  pnpm-version: "11.3.0"
   PACKAGE_NAME: gossip-site-blocker
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -49,5 +49,5 @@
     "vitest": "^4.1.7",
     "zip-a-folder": "6.1.1"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@11.3.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Summary

- Add `pnpm-workspace.yaml` with `allowBuilds: { esbuild: true }` to unblock pnpm v11 migration (companion to #2132).
- pnpm v11 removed `onlyBuiltDependencies` / `ignoredBuiltDependencies` and replaced them with `allowBuilds` (a package-name → bool map).
- Without this file, `esbuild`'s postinstall script is ignored and CI fails with `ERR_PNPM_IGNORED_BUILDS`.

## Notes

- The Renovate PR #2132 bumps `packageManager` to pnpm@11.3.0 but does not provide the workspace config. Merge this PR together with (or in place of) #2132.
- Branch is based on `renovate/pnpm-11.x`, so it already contains the pnpm@11 bump.

## References

- pnpm v11 release notes: https://pnpm.io/blog/releases/11.0
- Settings reference: https://pnpm.io/settings
- pnpm/pnpm#10235 (rename onlyBuiltDependencies / ignoredBuiltDependencies)

## Test plan

- [ ] CI passes (build + lint)
- [ ] No `ERR_PNPM_IGNORED_BUILDS` warnings in the install step

🤖 Generated with [Claude Code](https://claude.com/claude-code)