### PR TITLE
fix: remove negative margin that causes block anchor to overlap with search snippets

### DIFF
--- a/public/css/google.css
+++ b/public/css/google.css
@@ -210,8 +210,8 @@ g-inner-card:not([data-blocker-display="none"]) > span.block-anchor {
 }
 
 [data-gsb-element-type="google-search-result"] + .block-anchor {
-  margin-top: -22px;
-  margin-bottom: 22px;
+  margin-top: 0;
+  margin-bottom: 0;
 }
 
 [data-gsb-element-type="google-search-result"]


### PR DESCRIPTION
## Summary

Block anchor links ("このページをブロックする") were overlapping with Google search result snippet text due to a `margin-top: -22px` CSS rule.

This negative margin was added in 2018 to close the gap between search result elements and block anchors, but Google's current layout no longer has that bottom padding, causing a 22px overlap with snippet text.

Changed `margin-top` and `margin-bottom` to `0` for `.block-anchor` elements following `google-search-result` elements.

## Risk

- Low: removing the negative margin is a neutral default. If Google re-adds bottom padding in the future, block links will appear slightly separated rather than overlapping (safe failure mode).