### PR TITLE
fix: pull block anchor up by the measured gap under search results

### DIFF
--- a/apps/content_script/anchor_margin.ts
+++ b/apps/content_script/anchor_margin.ts
@@ -1,0 +1,42 @@
+const SEARCH_RESULT_TYPE = "google-search-result";
+
+// ignore sub-pixel rounding noise.
+const MIN_GAP_PX = 1;
+
+export interface AnchorMargins {
+  top: string;
+  bottom: string;
+}
+
+export function computeAnchorMargins(gap: number): AnchorMargins | null {
+  if (!Number.isFinite(gap) || gap < MIN_GAP_PX) {
+    return null;
+  }
+
+  return { top: `-${gap}px`, bottom: `${gap}px` };
+}
+
+/**
+ * Google ships multiple search result layouts. Depending on the layout, a
+ * visible gap appears between the result element and the inserted anchor
+ * (caused by bottom padding on the result, or by margins collapsing out of
+ * its descendants), while other layouts leave no gap at all. Measure the
+ * actually rendered gap and pull the anchor up by the same amount, so the
+ * anchor sits right under the snippet in any layout.
+ */
+export function adjustAnchorMargin(target: Element, anchor: HTMLElement): void {
+  if (target.getAttribute("data-gsb-element-type") !== SEARCH_RESULT_TYPE) {
+    return;
+  }
+
+  const gap =
+    anchor.getBoundingClientRect().top - target.getBoundingClientRect().bottom;
+  const margins = computeAnchorMargins(gap);
+
+  if (margins === null) {
+    return;
+  }
+
+  anchor.style.marginTop = margins.top;
+  anchor.style.marginBottom = margins.bottom;
+}

--- a/apps/content_script/block_mediator.ts
+++ b/apps/content_script/block_mediator.ts
@@ -4,6 +4,7 @@ import { BlockReason, BlockReasonType } from "../model/block_reason";
 import BlockedSitesRepository from "../storage/blocked_sites";
 import { BlockType, MenuPositionType } from "../storage/enums";
 import { RegExpRepository } from "../storage/regexp_repository";
+import { adjustAnchorMargin } from "./anchor_margin";
 import { BlockAnchor } from "./block_anchor";
 import { BlockChangeAnchor } from "./block_change_anchor";
 import { BlockChangeAnchorDialog } from "./block_change_anchor_dialog";
@@ -101,6 +102,7 @@ export class BlockMediator implements IBasicBlockMediator, IBlockMediator {
         this.operationDiv.appendChild(this.changeAnchor.getElement());
         this.operationDiv.classList.add(g.getCssClass());
         DOMUtils.insertAfter(blockTarget.getDOMElement(), this.operationDiv);
+        adjustAnchorMargin(blockTarget.getDOMElement(), this.operationDiv);
 
         break;
       default:

--- a/test/anchor_margin.test.ts
+++ b/test/anchor_margin.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  adjustAnchorMargin,
+  computeAnchorMargins,
+} from "../apps/content_script/anchor_margin";
+
+describe("computeAnchorMargins", () => {
+  it("returns margins that cancel the gap", () => {
+    expect(computeAnchorMargins(30)).toEqual({ top: "-30px", bottom: "30px" });
+  });
+
+  it("returns null when the gap is zero", () => {
+    expect(computeAnchorMargins(0)).toBeNull();
+  });
+
+  it("returns null for sub-pixel gaps", () => {
+    expect(computeAnchorMargins(0.5)).toBeNull();
+  });
+
+  it("returns null for NaN", () => {
+    expect(computeAnchorMargins(Number.NaN)).toBeNull();
+  });
+});
+
+describe("adjustAnchorMargin", () => {
+  function stubBottom(element: Element, bottom: number): void {
+    vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
+      bottom,
+      top: 0,
+    } as DOMRect);
+  }
+
+  function stubTop(element: Element, top: number): void {
+    vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
+      bottom: 0,
+      top,
+    } as DOMRect);
+  }
+
+  function createSearchResult(): HTMLDivElement {
+    const element = document.createElement("div");
+    element.setAttribute("data-gsb-element-type", "google-search-result");
+    return element;
+  }
+
+  it("pulls the anchor up by the rendered gap", () => {
+    const target = createSearchResult();
+    const anchor = document.createElement("div");
+    stubBottom(target, 100);
+    stubTop(anchor, 130);
+
+    adjustAnchorMargin(target, anchor);
+
+    expect(anchor.style.marginTop).toBe("-30px");
+    expect(anchor.style.marginBottom).toBe("30px");
+  });
+
+  it("leaves margins untouched when there is no gap", () => {
+    const target = createSearchResult();
+    const anchor = document.createElement("div");
+    stubBottom(target, 100);
+    stubTop(anchor, 100);
+
+    adjustAnchorMargin(target, anchor);
+
+    expect(anchor.style.marginTop).toBe("");
+    expect(anchor.style.marginBottom).toBe("");
+  });
+
+  it("ignores elements other than search results", () => {
+    const target = document.createElement("div");
+    target.setAttribute("data-gsb-element-type", "google-news-card");
+    const anchor = document.createElement("div");
+    stubBottom(target, 100);
+    stubTop(anchor, 130);
+
+    adjustAnchorMargin(target, anchor);
+
+    expect(anchor.style.marginTop).toBe("");
+    expect(anchor.style.marginBottom).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

#2159 removed the fixed `-22px` margin, which fixed the overlap on Google's new search layout but left the anchor visibly detached (~30px gap) on the old layout, which some users still get.

The gap on the old layout comes from descendant margins collapsing out of the result element — not from the result's own padding — so it cannot be detected from computed styles. Instead, measure the actually rendered gap right after inserting the anchor, and pull the anchor up by that amount.

## Risk

- Low: when no gap is measured (new layout), behavior is unchanged. If measurement misses, the anchor just appears slightly detached (current behavior, safe failure mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)