### PR TITLE
chore: bump version to 1.17.1 for production release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gossip-site-blocker",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "license": "MIT",
   "author": "Hideki Ikemoto",
   "type": "module",

--- a/public/manifest.firefox.json
+++ b/public/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "default_locale": "en",
   "description": "__MSG_extensionDescription__",
   "icons": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "default_locale": "en",
   "description": "__MSG_extensionDescription__",
   "icons": {


### PR DESCRIPTION
Bump version to 1.17.1 in package.json and both manifests.

Release contents: #2159, #2164 (block anchor position fixes for Google search results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)