### PR TITLE
fix: update shell-quote to 1.8.4 to fix vulnerability

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1238,8 +1238,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -2447,7 +2447,7 @@ snapshots:
       picomatch: 4.0.4
       pidtree: 0.6.0
       read-package-json-fast: 6.0.0
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       which: 7.0.0
 
   obug@2.1.1: {}
@@ -2562,7 +2562,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   siginfo@2.0.0: {}
 


### PR DESCRIPTION
## Changes

Update shell-quote (critical) to the patched version 1.8.4.

- shell-quote: 1.8.3 → 1.8.4 (patch update, transitive via npm-run-all2)

## Resolved alerts (1)

- [alert 52](https://github.com/ikemo3/gossip-site-blocker/security/dependabot/52): shell-quote critical (patched in 1.8.4, pnpm-lock.yaml)

## Risk assessment

Patch update only. No other packages changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)