### PR TITLE
fix: update undici to 7.28.0 to resolve vulnerability

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,9 +502,6 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@24.13.1':
-    resolution: {integrity: sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==}
-
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
 
@@ -1366,8 +1363,8 @@ packages:
   undici-types@7.22.0:
     resolution: {integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   uri-js@4.4.1:
@@ -1797,16 +1794,12 @@ snapshots:
 
   '@types/jsdom@28.0.3':
     dependencies:
-      '@types/node': 24.13.1
+      '@types/node': 24.13.2
       '@types/tough-cookie': 4.0.5
       parse5: 8.0.1
       undici-types: 7.22.0
 
   '@types/json-schema@7.0.15': {}
-
-  '@types/node@24.13.1':
-    dependencies:
-      undici-types: 7.18.2
 
   '@types/node@24.13.2':
     dependencies:
@@ -2327,7 +2320,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -2674,7 +2667,7 @@ snapshots:
 
   undici-types@7.22.0: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Update undici from 7.25.0 to 7.28.0 (transitive dependency via jsdom)
- Resolves 2 Dependabot security alerts (1 high, 1 medium)

## Resolved alerts

- [alert 56](https://github.com/ikemo3/gossip-site-blocker/security/dependabot/56): undici high (fixed in 7.28.0)
- [alert 55](https://github.com/ikemo3/gossip-site-blocker/security/dependabot/55): undici medium (fixed in 7.28.0)

## Risk assessment

Minor update of a transitive devDependency (jsdom → undici). No production impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012u7SF3Z8QYhcwhLThymvA7